### PR TITLE
Allow evaluating fairness for chosen model

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,12 @@ image classification. Training runs for 3 epochs using the Adam optimizer.
 **Dataset splitting:** After `/setup_dataset`, the data is split into train (40%), validation (20%), holdout (20%), and
 test (20%) subsets using a fixed random seed. Endpoints `/train_initial_model` and `/run_iterative_augmentation_cycle`
 train on the combined train+validation sets, `/evaluate_fairness` evaluates performance on the test set, and guide
-images for augmentation are sampled from the holdout set only.
+images for augmentation are sampled from the holdout set only. The fairness endpoint requires the name of the model
+file (e.g. `model.pth`) to evaluate.
 
 - `POST /setup_dataset`
 - `POST /train_initial_model` (optional JSON body `{"use_augmented": bool}`; when true, includes previously generated augmented images in the training data)
-- `GET /evaluate_fairness`
+- `GET /evaluate_fairness?model_name=<file.pth>`
 - `POST /run_iterative_augmentation_cycle`
 
   When running augmentation, k guide images are sampled from the misclassified holdout images of the worst-performing

--- a/routers/orchestration_router.py
+++ b/routers/orchestration_router.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from services import data_service, model_service, fairness_service, llm_augmentation_service
-from utils.config import AUGMENTED_IMAGES_DIR
+from utils.config import AUGMENTED_IMAGES_DIR, TRAINED_MODELS_DIR
 
 
 def _serialize_group_performance(attrs_tuple, metrics):
@@ -79,13 +79,14 @@ def train_initial_model(req: TrainInitialModelRequest):
 
 
 @router.get("/evaluate_fairness")
-def evaluate_fairness():
-    logging.debug("evaluate_fairness called")
+def evaluate_fairness(model_name: str):
+    logging.debug(f"evaluate_fairness called with model_name={model_name}")
     try:
-        model_path = model_service.get_current_model_path()
-        logging.debug(f"Current model_path: {model_path}")
-        if not model_path:
-            raise HTTPException(status_code=400, detail="No model trained.")
+        model_file = TRAINED_MODELS_DIR / model_name
+        logging.debug(f"Resolved model_path: {model_file}")
+        if not model_file.exists():
+            raise HTTPException(status_code=400, detail="Model not found.")
+        model_path = str(model_file)
         df = data_service.get_test_metadata_df()
         logging.debug(f"Test metadata DataFrame obtained: {len(df)} records")
         image_paths, _ = data_service.get_test_image_paths_and_labels()


### PR DESCRIPTION
## Summary
- accept a `model_name` query parameter in the `/evaluate_fairness` endpoint
- load the model from `trained_models` by name before evaluation
- document new endpoint usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ac18a460832a9b5f4cbd9e35e48f